### PR TITLE
Feature/dashboard links

### DIFF
--- a/src/Utilities/interfaces.tsx
+++ b/src/Utilities/interfaces.tsx
@@ -13,7 +13,6 @@ export interface IUserData {
 }
 
 export interface IChallenge {
-  challenge_id: string,
   language: string,
   verb: string,
   eng_verb: string,

--- a/src/components/ChallengeCard/ChallengeCard.tsx
+++ b/src/components/ChallengeCard/ChallengeCard.tsx
@@ -6,7 +6,7 @@ interface IProps {
   eng_verb: string,
   image_url: string,
   image_alt_text: string,
-  date: string
+  date: string,
 }
 
 const ChallengeCard = ({ verb, eng_verb, image_url, image_alt_text, date }: IProps) => {

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { IUser } from '../../Utilities/interfaces';
+import { Link } from 'react-router-dom';
 import mockUser from '../../sampleData/user';
 import PastChallenges from '../PastChallenges/PastChallenges';
 import './Dashboard.css';
@@ -10,7 +11,7 @@ const Dashboard = () => {
   return (
     <div className='dashboard'>
       <PastChallenges challenges={userData.data.attributes.challenges}/>
-      <button>New Challenge</button>
+      <Link to='/Deniz/new-challenge'><button>New Challenge</button></Link>
     </div>
   );
 }

--- a/src/components/PastChallenges/PastChallenges.tsx
+++ b/src/components/PastChallenges/PastChallenges.tsx
@@ -1,17 +1,8 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { IChallenge } from '../../Utilities/interfaces';
 import ChallengeCard from '../ChallengeCard/ChallengeCard';
 import './PastChallenges.css';
-
-interface IChallenge {
-  challenge_id: string,
-  language: string,
-  verb: string,
-  eng_verb: string,
-  image_url: string,
-  image_alt_text: string,
-  created_at: string
-}
 
 interface IProps {
   challenges: IChallenge[]

--- a/src/components/PastChallenges/PastChallenges.tsx
+++ b/src/components/PastChallenges/PastChallenges.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import ChallengeCard from '../ChallengeCard/ChallengeCard';
 import './PastChallenges.css';
 
@@ -21,13 +22,14 @@ const PastChallenges = ({ challenges }: IProps) => {
 
   const challengeCards = pastChallenges.map(challenge => {
     return (
+      <Link to='/Deniz/feedback/:challenge-id'>
       <ChallengeCard 
         verb={challenge.verb}
         eng_verb={challenge.eng_verb}
         image_url={challenge.image_url}
         image_alt_text={challenge.image_alt_text}
         date={challenge.created_at}
-      />
+      /></Link>
     )
   })
 


### PR DESCRIPTION
# Description

This branch adds linking for the dashboard component. The 'new challenge' button in the component now links to the new-challenge route. And all 'challenge cards' are now properly linked to the feedback component.

I noticed we added the :challenge_id to this route (my bad) when we are hard coding it for now, so it just links to that exact url. But once we have the match.params functionality in our routes we will be able to update that so it dynamically connects the id of the clicked challenge card to the url!

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tested this functionality by navigating to dashboard link and clicking both a challenge card and the new challenge button to ensure they were linking to the proper pages.

- local host
- dev tools
- terminal

# Related Issues:

None

# Checklist:

- [x] My code follows the Turing's guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No console error messages