### PR TITLE
feat: Setup Link components in Form and Feedback

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -35,7 +35,7 @@ const App = () => {
         <Route path='/' element={<Home />} />
         <Route path='/Deniz/dashboard' element={<Dashboard />} />
         <Route path='/Deniz/new-challenge' element={<Form />} />
-        <Route path='/Deniz/feedback/:challenge-id' element={<Feedback />} />
+        <Route path='/Deniz/feedback/:id' element={<Feedback />} />
       </Routes>
     </>
   );

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { ISentences } from '../../Utilities/interfaces';
 import './Feedback.css';
 
@@ -35,7 +36,10 @@ const Feedback = () => {
         <p>{sentences[0].user_sent}</p>
         <h5>Corrected Sentence</h5>
         <p>{sentences[0].ai_sent}</p>
-        <button>Home</button>
+        {/* Will need to make the username dynamic */}
+        <Link to={'/Deniz/dashboard'}>
+          <button>Home</button>
+        </Link>
       </div>}
     </div>
   );

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { IGrammarPoint } from '../../Utilities/interfaces';
 import './Form.css';
 import infoIcon from '../../assets/info_icon.svg';
@@ -51,7 +52,10 @@ const Form = () => {
           placeholder='Enter your sentence'
           onChange={event => setSent2(event.target.value)}
         />
-      <button>Submit</button>
+        {/* Will need to make this route dynamic in the future */}
+      <Link to={'/Deniz/feedback/1'}>
+        <button>Submit</button>
+      </Link>
       </div>
     </form>
   );


### PR DESCRIPTION
# Description

This adds `Link` components in `Form` and `Feedback`. The "Submit" button in `Form` will link to the user's feedback page and the "Home" button in `Feedback` will link back to the user's dashboard.

I had to change the endpath in `Feedback`'s route in `App` on line 38. The trailing dash in `:challenge-id` was preventing it from being dynamic, so I just changed it to `:id`. Not sure why Router didn't like it, but there you go.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I made sure there were no warnings when the dev server was launched and no errors appeared in the dev tools.

- local host
- dev tools
- terminal

# Related Issues:

- and/or related to #9 

# Checklist:

- [x] My code follows the Turing's guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No console error messages