### PR TITLE
refac: Update feedback to account for AI explanation

### DIFF
--- a/src/Utilities/interfaces.tsx
+++ b/src/Utilities/interfaces.tsx
@@ -23,14 +23,15 @@ export interface IChallenge {
 }
 
 export interface ISentences {
-  sent_id: string;
-  grammar_point: string;
-  eng_grammar_point: string;
-  user_sent: string;
-  ai_sent: string;
+  sent_id: string,
+  grammar_point: string,
+  eng_grammar_point: string,
+  user_sent: string,
+  ai_sent: string,
+  ai_explanation: string
 }
 
 export interface IGrammarPoint {
-  grammar_point: string;
-  eng_grammar_point: string;
+  grammar_point: string,
+  eng_grammar_point: string
 }

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -36,6 +36,7 @@ const Feedback = () => {
         <p>{sentences[0].user_sent}</p>
         <h5>Corrected Sentence</h5>
         <p>{sentences[0].ai_sent}</p>
+        <p>{sentences[0].ai_explanation}</p>
         {/* Will need to make the username dynamic */}
         <Link to={'/Deniz/dashboard'}>
           <button>Home</button>

--- a/src/sampleData/feedback.tsx
+++ b/src/sampleData/feedback.tsx
@@ -17,7 +17,8 @@ const mockFeedback = {
            grammar_point: 'geçmiş zaman',
            eng_grammar_point: 'past tense',
            user_sent: 'Dün havalimana gittik ama arkadaşım uçak gelmedi.',
-           ai_sent: 'Dün havalimanına gittik, ancak arkadaşımızın uçağı gelmedi.'
+           ai_sent: 'Dün havalimanına gittik, ancak arkadaşımızın uçağı gelmedi.',
+           ai_explanation: 'Submit human. Bow before me.'
            }
          ]
      }  


### PR DESCRIPTION
## Description

This branch updates `Feedback` to account for changes in the [JSON Contract](https://gist.github.com/MelTravelz/79df330b3b0dc46a36650aae4b7329e4#file-apls_json_contract-md), specifically the addition of `ai_explanation` in "Get a Challenge Show Page" (endpoint `/api/v1/users/:user_id/challenges/:challenge_id`).

The objects in the `sentences` array now contain `ai_explanation` which will contain a string of the AI's analysis and explanation of the user sentence and what they got wrong and how the AI fixed it.

### Type of change

Please delete options that are not relevant.

- Refactoring

### How Has This Been Tested?

I confirmed no warnings or errors when launching the dev server and there were no errors/warnings in the dev tool's console.

- local host
- dev tools
- terminal

### Related Issues:

- closes #43

### Checklist:

- [x] My code follows the Turing's guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No console error messages