### PR TITLE
feat: Link header to home

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 import './Header.css';
+import { Link } from 'react-router-dom';
 
 interface IProps {
   userName: string | undefined
@@ -7,7 +8,7 @@ interface IProps {
 const Header = ({ userName}: IProps) => {
   return (
     <div className='header'>
-      <h1>ALPs</h1>
+      <Link to='/' style={{textDecoration: 'none'}}><h1>ALPs</h1></Link>
       {userName && <p className='welcome-msg'>Welcome, {userName}!</p>}
     </div>
   );


### PR DESCRIPTION
# Description

Quick addition: Links the h1 in the header component to home for UI/UX

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

No errors and navigation works in the local host!

- local host
- dev tools
- terminal

# Related Issues:

- closes #53 

# Checklist:

- [x] My code follows the Turing's guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No console error messages