### PR TITLE
Refactor/dashboard persistence

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -4,7 +4,7 @@ import Home from '../Home/Home';
 import Dashboard from '../Dashboard/Dashboard';
 import Form from '../Form/Form';
 import Feedback from '../Feedback/Feedback';
-import { Routes, Route, useParams } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import './App.css';
 import { IUsers, IUser } from '../../Utilities/interfaces';
 import { useState, useEffect } from 'react';

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -4,7 +4,7 @@ import Home from '../Home/Home';
 import Dashboard from '../Dashboard/Dashboard';
 import Form from '../Form/Form';
 import Feedback from '../Feedback/Feedback';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useParams } from 'react-router-dom';
 import './App.css';
 import { IUsers, IUser } from '../../Utilities/interfaces';
 import { useState, useEffect } from 'react';
@@ -38,9 +38,9 @@ const App = () => {
       <Header userName={user?.data.attributes.name}/>
       <Routes>
         <Route path='/' element={users !== null && <Home allUsers={users} setUserData={setUserData} resetUser={resetUser}/>} />
-        <Route path='/:userName/dashboard' element={user !== null && <Dashboard user={user}/>}/>
-        <Route path='/Deniz/new-challenge' element={<Form />} />
-        <Route path='/Deniz/feedback/:id' element={<Feedback />} />
+        <Route path='/:userId/dashboard' element={<Dashboard user={user} setUserData={setUserData}/>}/>
+        <Route path='/:userId/new-challenge' element={<Form />} />
+        <Route path='/:userId/feedback/:id' element={<Feedback />} />
       </Routes>
     </>
   );

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -37,7 +37,7 @@ const App = () => {
     <>
       <Header userName={user?.data.attributes.name}/>
       <Routes>
-        <Route path='/' element={users !== null && <Home allUsers={users} setUserData={setUserData} resetUser={resetUser}/>} />
+        <Route path='/' element={users !== null && <Home allUsers={users} resetUser={resetUser}/>} />
         <Route path='/:userId/dashboard' element={<Dashboard user={user} setUserData={setUserData}/>}/>
         <Route path='/:userId/new-challenge' element={<Form />} />
         <Route path='/:userId/feedback/:id' element={<Feedback />} />

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,9 +1,8 @@
 import { IUser } from '../../Utilities/interfaces';
 import { Link, useParams } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import PastChallenges from '../PastChallenges/PastChallenges';
 import './Dashboard.css';
-import { param } from 'cypress/types/jquery';
 
 interface IProps {
   user: IUser | null,

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -14,7 +14,7 @@ const Dashboard = ({ user, setUserData }: IProps) => {
 
   useEffect(() => {
     setUserData(paramsData.userId)
-  }, [paramsData.userId, setUserData])
+  }, [])
 
   return (
     <div className='dashboard'>

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -14,7 +14,7 @@ const Dashboard = ({ user, setUserData }: IProps) => {
 
   useEffect(() => {
     setUserData(paramsData.userId)
-  }, [paramsData.userId])
+  }, [paramsData.userId, setUserData])
 
   return (
     <div className='dashboard'>

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,18 +1,30 @@
 import { IUser } from '../../Utilities/interfaces';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import PastChallenges from '../PastChallenges/PastChallenges';
 import './Dashboard.css';
+import { param } from 'cypress/types/jquery';
 
 interface IProps {
-  user: IUser
+  user: IUser | null,
+  setUserData: Function
 }
 
-const Dashboard = ({ user }: IProps) => {
+const Dashboard = ({ user, setUserData }: IProps) => {
+  const paramsData = useParams()
+
+  useEffect(() => {
+    setUserData(paramsData.userId)
+  }, [])
 
   return (
     <div className='dashboard'>
-      {user.data.attributes.challenges && <PastChallenges challenges={user.data.attributes.challenges}/>}
-      <Link to='/Deniz/new-challenge'><button>New Challenge</button></Link>
+      { user &&
+      <div className='past-challenges'>
+        { user.data.attributes.challenges && <PastChallenges challenges={user.data.attributes.challenges}/>}
+        <Link to={`/${user.data.id}/new-challenge`}><button>New Challenge</button></Link>
+      </div>
+      }
     </div>
   );
 }

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -14,6 +14,7 @@ const Dashboard = ({ user, setUserData }: IProps) => {
 
   useEffect(() => {
     setUserData(paramsData.userId)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -14,7 +14,7 @@ const Dashboard = ({ user, setUserData }: IProps) => {
 
   useEffect(() => {
     setUserData(paramsData.userId)
-  }, [])
+  }, [paramsData.userId])
 
   return (
     <div className='dashboard'>

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -38,7 +38,7 @@ const Feedback = () => {
         <p>{sentences[0].ai_sent}</p>
         <p>{sentences[0].ai_explanation}</p>
         {/* Will need to make the username dynamic */}
-        <Link to={'/Deniz/dashboard'}>
+        <Link to={'/55/dashboard'}>
           <button>Home</button>
         </Link>
       </div>}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 import './Header.css';
+import { Link } from 'react-router-dom';
 
 interface IProps {
   userName: string | undefined
@@ -7,7 +8,7 @@ interface IProps {
 const Header = ({ userName}: IProps) => {
   return (
     <div className='header'>
-      <h1>ALPs</h1>
+      <Link to='/' style={{textDecoration: 'none'}}><h1>ALPs</h1></Link>
       {userName && <p className='welcome-msg'>Welcome, {userName}!</p>}
     </div>
   );

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -6,11 +6,10 @@ import { useEffect } from 'react';
 
 interface IProps {
   allUsers: IUsers
-  setUserData: Function
   resetUser: Function
 }
 
-const Home = ({ allUsers, setUserData, resetUser }: IProps) => {
+const Home = ({ allUsers, resetUser }: IProps) => {
   const [userCards, setUserCards] = useState<JSX.Element[] | null >(null)
 
   useEffect(() => {
@@ -20,11 +19,11 @@ const Home = ({ allUsers, setUserData, resetUser }: IProps) => {
   useEffect(() => {
     if(allUsers.data.length) {
       let cards = allUsers.data.map(user => {
-      return <User name={user.attributes.name} preferred_lang={user.attributes.preferred_lang} id={user.id} key={user.id} setUserData={setUserData}/>
+      return <User name={user.attributes.name} preferred_lang={user.attributes.preferred_lang} id={user.id} key={user.id}/>
       })
       setUserCards(cards)
     }
-  }, [allUsers, setUserData])
+  }, [allUsers])
 
   return (
     <div>

--- a/src/components/User/User.tsx
+++ b/src/components/User/User.tsx
@@ -15,7 +15,7 @@ const User: React.FC<IProps> = ({ name, preferred_lang, id, setUserData}) => {
     <div className='user'>
       <p>{name}</p>
       <p>{preferred_lang}</p>
-      <Link to={`/${name}/dashboard`}><button onClick={() => setUserData(id)}>{`Continue as ${name}`}</button></Link>
+      <Link to={`/${id}/dashboard`}><button onClick={() => setUserData(id)}>{`Continue as ${name}`}</button></Link>
     </div>
   );
 }

--- a/src/components/User/User.tsx
+++ b/src/components/User/User.tsx
@@ -6,16 +6,15 @@ interface IProps {
   name: string,
   preferred_lang: string,
   id: string
-  setUserData: Function
 }
 
-const User: React.FC<IProps> = ({ name, preferred_lang, id, setUserData}) => {
+const User: React.FC<IProps> = ({ name, preferred_lang, id }) => {
 
   return (
     <div className='user'>
       <p>{name}</p>
       <p>{preferred_lang}</p>
-      <Link to={`/${id}/dashboard`}><button onClick={() => setUserData(id)}>{`Continue as ${name}`}</button></Link>
+      <Link to={`/${id}/dashboard`}><button>{`Continue as ${name}`}</button></Link>
     </div>
   );
 }


### PR DESCRIPTION
# Description

This adds a useEffect on the Dashboard component so that the user is able to refresh their dashboard and the user data is still accessible in the component and it can render the information on the DOM.

Dashboard uses the useParams hook so that whenever the component is rendered, user data is generated based on the id value in the url. I removed the existing logic that was performing this selection prior to this PR that generated user data when a user clicked a user card.

I removed the conditional rendering for the dashboard component on App to provide this functionality, and added the conditionals in the Dashboard component itself.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Refactoring

# How Has This Been Tested?

Tried refreshing in local host and the dashboard data persists!

- local host
- dev tools
- terminal

# Related Issues:

- closes #45 
- and/or related to #<issue number>

# Checklist:

- [x] My code follows the Turing's guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No console error messages