### PR TITLE
Feature/cypress feeback flow

### DIFF
--- a/cypress/e2e/feedback_spec.cy.ts
+++ b/cypress/e2e/feedback_spec.cy.ts
@@ -32,4 +32,12 @@ describe ('Feedback flow', () => {
       .and('contain', 'Feedback')
       .and('contain', 'This sentence is correct. Nice work rockstar!');
     })
+
+    it('should return to dashboard view when user clicks back button from feedback view', () => {
+        cy.visit('http://localhost:3000/1/feedback/100');
+     
+        cy.get('button').click();
+        cy.url().should('include', '/dashboard');
+        cy.get('.challenge-card-container').should('be.visible');
+      })
 })

--- a/cypress/e2e/feedback_spec.cy.ts
+++ b/cypress/e2e/feedback_spec.cy.ts
@@ -1,0 +1,8 @@
+describe ('Feedback flow', () => {
+  beforeEach('intercept all endpoints', () => {
+    cy.visit('http://localhost:3000');
+  });
+
+
+
+} )

--- a/cypress/e2e/feedback_spec.cy.ts
+++ b/cypress/e2e/feedback_spec.cy.ts
@@ -3,6 +3,12 @@ describe ('Feedback flow', () => {
     cy.visit('http://localhost:3000');
   });
 
+  it('should show the user dashboard once a user is selected', () => {
+    cy.get(':nth-child(1) > a > button')
+      .first()
+      .click();
+ 
+    cy.get('.challenge-card-container').should('be.visible');
+  });
 
-
-} )
+})

--- a/cypress/e2e/feedback_spec.cy.ts
+++ b/cypress/e2e/feedback_spec.cy.ts
@@ -11,4 +11,25 @@ describe ('Feedback flow', () => {
     cy.get('.challenge-card-container').should('be.visible');
   });
 
+  it ('should render past feedback with all elements', () => {
+    cy.get(':nth-child(1) > a > button')
+      .first()
+      .click();
+ 
+    cy.get('.challenge-card-container').should('be.visible') ;
+    cy.get('[href="/1/feedback/100"] > .challenge-card > .card-right-content')
+      .first()
+      .click();
+ 
+    cy.get('.feedback-container') 
+      .should('contain', 'Your challenge from 05/23/2023')
+      .and('contain', 'Sentence #1')
+      .and('contain', 'presente ✴ simple present tense')
+      .and('contain', 'Your response')
+      .and('contain', 'Él habla español y francés con fluidez.')
+      .and('contain', 'Corrected Sentence')
+      .and('contain', 'Él habla español y francés con fluidez.')
+      .and('contain', 'Feedback')
+      .and('contain', 'This sentence is correct. Nice work rockstar!');
+    })
 })


### PR DESCRIPTION
# Description

Added spec for testing feedback flow including seeing the user dashboard once user is selected, navigating to feedback view once a past challenge card is selected and returning to dashboard view after clicking back button.

## Type of change

Please delete options that are not relevant.

- Testing

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- local host
- dev tools
- terminal

# Related Issues:

- closes #85 


# Checklist:

- [X] My code follows the Turing's guidelines of this project
- [X] I have performed a self-review of my own code
- [X] No console error messages